### PR TITLE
Fix server rendering by renaming window to global.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -9,7 +9,7 @@ var ExtendedComponent = require('./ExtendedComponent.js');
 var dispatcher = new ReactDispatcher();
 
 React.debug = function () {
-	window.React = React;
+	global.React = React;
 };
 
 var createClass = React.createClass;


### PR DESCRIPTION
Refering to window doesn't work when using it with node. Setting it to global works on the server AND the browser, since browserify makes it a reference to window.
